### PR TITLE
Return last insert id after insert

### DIFF
--- a/src/lib360/db/data/ITable.php
+++ b/src/lib360/db/data/ITable.php
@@ -93,7 +93,7 @@ interface ITable extends IStore
      * @param array $fields associative array of fields for insert
      *    (table field) => (update value)
      *
-     * @return integer number of rows inserted
+     * @return mixed inserted row ID
      */
     public function insert(array $fields);
 

--- a/src/lib360/db/data/Table.php
+++ b/src/lib360/db/data/Table.php
@@ -48,7 +48,7 @@ class Table extends Store implements ITable
     /**
      * Table primary key.
      */
-    protected $key;
+    public $key;
 
     /**
      * Gets table records by field criteria.
@@ -200,7 +200,7 @@ class Table extends Store implements ITable
      * @param array $fields associative array of fields for insert
      *    (table field) => (insert value)
      *
-     * @return integer number of rows inserted
+     * @return mixed inserted row ID
      */
     public function insert(array $fields)
     {

--- a/src/lib360/db/executor/IExecutor.php
+++ b/src/lib360/db/executor/IExecutor.php
@@ -62,7 +62,7 @@ interface IExecutor
      * @param string $query prepared query statement
      * @param array $values optional array of values for prepared statement
      *
-     * @return integer number of rows inserted
+     * @return mixed inserted row ID
      *
      * @throw \spoof\lib360\db\Exception when database error occurs during query execution
      */

--- a/src/lib360/db/executor/PDO.php
+++ b/src/lib360/db/executor/PDO.php
@@ -191,6 +191,20 @@ class PDO implements IExecutor
     }
 
     /**
+     * Executes query and returns last inserted ID.
+     *
+     * @param IConnection $conn database connection object
+     * @param string $query prepared query statement
+     * @param array $values optional array of values for prepared statement
+     *
+     * @return mixed inserted row ID
+     */
+    private function queryLastInsertId(IConnection $conn, $query, array $values = null)
+    {
+        $sth = $this->queryStatementClose($conn, $query, $values);
+        return $conn->getConnection()->lastInsertId();
+    }
+    /**
      *    Executes query and gets closed statement handle.
      *
      * @param IConnection $conn database connection object
@@ -213,13 +227,13 @@ class PDO implements IExecutor
      * @param string $query prepared query statement
      * @param array $values optional array of values for prepared statement
      *
-     * @return integer number of rows inserted
+     * @return mixed inserted row ID
      *
      * @throw PreparedQueryException when database error occurs during query execution
      */
     public function insert(IConnection $conn, $query, array $values = null)
     {
-        return $this->queryAffectedCount($conn, $query, $values);
+        return $this->queryLastInsertId($conn, $query, $values);
     }
 
     /**

--- a/src/tests/lib360/db/data/HelperTableUser.php
+++ b/src/tests/lib360/db/data/HelperTableUser.php
@@ -25,7 +25,8 @@ class HelperTableUser extends \spoof\lib360\db\data\Table
 
     protected $name = 'user';
     protected $db = 'test';
-    protected $key = 'id';
+    public $key = 'id';
+    public $fields = array('id', 'date_created', 'name_first', 'name_last', 'status');
 
 }
 

--- a/src/tests/lib360/db/data/HelperTableUserBadPrimaryKey.php
+++ b/src/tests/lib360/db/data/HelperTableUserBadPrimaryKey.php
@@ -25,7 +25,7 @@ class HelperTableUserBadPrimaryKey extends \spoof\lib360\db\data\Table
 
     protected $name = 'user';
     protected $db = 'test';
-    protected $key = 'name_first';
+    public $key = 'name_first';
 
 }
 

--- a/src/tests/lib360/db/data/TableTest.php
+++ b/src/tests/lib360/db/data/TableTest.php
@@ -505,12 +505,13 @@ class TableTest extends \spoof\tests\lib360\db\DatabaseTestCase
         );
         $resultExpected = array(
             'rows' => 1,
+            'inserted_id' => $valueID,
             'id' => $valueID,
             'name_first' => $valueNameFirst,
             'name_last' => $valueNameLast
         );
         $user = new HelperTableUser();
-        $user->insert($values);
+        $resultActualInsertedID = $user->insert($values);
         $resultActualRows = $user->select(
             new Condition(
                 new Value('id', Value::TYPE_COLUMN),
@@ -522,6 +523,7 @@ class TableTest extends \spoof\tests\lib360\db\DatabaseTestCase
         );
         $resultActual = array();
         $resultActual['rows'] = count($resultActualRows);
+        $resultActual['inserted_id'] = $resultActualInsertedID;
         $resultActual['id'] = $resultActualRows[0]->id;
         $resultActual['name_first'] = $resultActualRows[0]->name_first;
         $resultActual['name_last'] = $resultActualRows[0]->name_last;

--- a/src/tests/lib360/db/executor/PDOTest.php
+++ b/src/tests/lib360/db/executor/PDOTest.php
@@ -311,7 +311,7 @@ class PDOTest extends \spoof\tests\lib360\db\DatabaseTestCase
 
     /**
      * @covers  \spoof\lib360\db\executor\PDO::insert
-     * @covers  \spoof\lib360\db\executor\PDO::queryAffectedCount
+     * @covers  \spoof\lib360\db\executor\PDO::queryLastInsertId
      * @covers  \spoof\lib360\db\executor\PDO::queryStatementClose
      * @covers  \spoof\lib360\db\executor\PDO::queryStatementLive
      * @covers  \spoof\lib360\db\executor\PDO::getStatement
@@ -331,9 +331,9 @@ class PDOTest extends \spoof\tests\lib360\db\DatabaseTestCase
             'name_last' => new Value($paramNameLast, Value::TYPE_STRING)
         );
         $ex = Factory::get(Factory::OBJECT_TYPE_EXECUTOR, 'PDO');
-        $resultActualNumRows = $ex->insert($this->db, $queryString, $queryValues);
+        $resultActualInsertedID = $ex->insert($this->db, $queryString, $queryValues);
         $resultActualID = $this->db->getConnection()->lastInsertId();
-        $resultActual = array($resultActualNumRows, $resultActualID, $paramNameFirst, $paramNameLast);
+        $resultActual = array($resultActualInsertedID, $resultActualID, $paramNameFirst, $paramNameLast);
         $sthExpected = self::$pdo->prepare("select id, name_first, name_last from user where id = :id");
         $sthExpected->bindValue(':id', $resultActualID, \PDO::PARAM_INT);
         $sthExpected->execute();
@@ -341,7 +341,7 @@ class PDOTest extends \spoof\tests\lib360\db\DatabaseTestCase
         $resultExpectedArray = $sthExpected->fetchAll();
         $sthExpected->closeCursor();
         $resultExpected = array(
-            1,
+            $resultExpectedArray[0]->id,
             $resultExpectedArray[0]->id,
             $resultExpectedArray[0]->name_first,
             $resultExpectedArray[0]->name_last


### PR DESCRIPTION
Instead of returning affected row count after running an insert, we now return the last inserted ID, which seems more useful.