### PR TITLE
Export models and records to array

### DIFF
--- a/src/lib360/db/data/IModel.php
+++ b/src/lib360/db/data/IModel.php
@@ -100,6 +100,13 @@ interface IModel
      */
     public function setTable();
 
+    /**
+     * Exports model to array representation.
+     *
+     * @return array associative array with field names as indexes
+     */
+    public function toArray();
+
 }
 
 ?>

--- a/src/lib360/db/data/IRecord.php
+++ b/src/lib360/db/data/IRecord.php
@@ -122,14 +122,14 @@ interface IRecord
     public function clear();
 
     /**
-     * Transforms object into array representation.
+     * Exports record to array representation.
      *
      * @return array associative array, field names as indexes
      */
     public function toArray();
 
     /**
-     * Transforms object into XML representation.
+     * Exports record to XML representation.
      *
      * @return \DOMDocument XML document object
      */

--- a/src/lib360/db/data/IRecord.php
+++ b/src/lib360/db/data/IRecord.php
@@ -122,6 +122,13 @@ interface IRecord
     public function clear();
 
     /**
+     * Transforms object into array representation.
+     *
+     * @return array associative array, field names as indexes
+     */
+    public function toArray();
+
+    /**
      * Transforms object into XML representation.
      *
      * @return \DOMDocument XML document object

--- a/src/lib360/db/data/Model.php
+++ b/src/lib360/db/data/Model.php
@@ -210,6 +210,16 @@ abstract class Model implements IModel
         $this->record = $record;
     }
 
+    /**
+     * Exports model to array representation.
+     *
+     * @return array associative array with field names as indexes
+     */
+    public function toArray()
+    {
+        return $this->record->toArray();
+    }
+
 }
 
 ?>

--- a/src/lib360/db/data/Record.php
+++ b/src/lib360/db/data/Record.php
@@ -186,7 +186,7 @@ class Record extends \ArrayObject implements IRecord
     }
 
     /**
-     * Transforms object into array representation.
+     * Exports record to array representation.
      *
      * @return array associative array, field names as indexes
      */
@@ -196,7 +196,7 @@ class Record extends \ArrayObject implements IRecord
     }
 
     /**
-     * Transforms object into XML representation.
+     * Exports record to XML representation.
      *
      * @return \DOMDocument XML document object
      */

--- a/src/lib360/db/data/Record.php
+++ b/src/lib360/db/data/Record.php
@@ -186,6 +186,16 @@ class Record extends \ArrayObject implements IRecord
     }
 
     /**
+     * Transforms object into array representation.
+     *
+     * @return array associative array, field names as indexes
+     */
+    public function toArray()
+    {
+        return (array)$this;
+    }
+
+    /**
      * Transforms object into XML representation.
      *
      * @return \DOMDocument XML document object

--- a/src/tests/lib360/db/data/ModelTest.php
+++ b/src/tests/lib360/db/data/ModelTest.php
@@ -248,6 +248,26 @@ class ModelTest extends \spoof\tests\lib360\db\DatabaseTestCase
         );
     }
 
+    /**
+     * @covers \spoof\lib360\db\data\Model::toArray
+     * @depends testSet_Success
+     */
+    public function testToArray()
+    {
+        $model = HelperModelUser::create();
+        $model->set('name_first', 'value 1');
+        $model->set('name_last', 'value 2');
+        $model->set('status', 'value 3');
+        $expected = array(
+            'id' => null,
+            'date_created' => null,
+            'name_first' => 'value 1',
+            'name_last' => 'value 2',
+            'status' => 'value 3',
+        );
+        $this->assertEquals($expected, $model->toArray(), "Array conversion didn't match expected");
+    }
+
 }
 
 ?>

--- a/src/tests/lib360/db/data/RecordTest.php
+++ b/src/tests/lib360/db/data/RecordTest.php
@@ -261,6 +261,20 @@ class RecordTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \spoof\lib360\db\data\Record::toArray
+     * @depends test__Set
+     * @depends test__Get_Success
+     */
+    public function testToArray()
+    {
+        $record = new Record();
+        $record->key1 = 'value 1';
+        $record->key2 = 'value 2';
+        $expected = array('key1' => 'value 1', 'key2' => 'value 2');
+        $this->assertEquals($expected, $record->toArray(), "Array conversion didn't match expected");
+    }
+
+    /**
      * @covers  \spoof\lib360\db\data\Record::toXML
      * @depends test__Set
      * @depends test__Get_Success


### PR DESCRIPTION
This adds ability to export `Model` and `Record` class instances to array representations. Closes #16.