### PR TITLE
Add base test class, move getProtectedProperty out

### DIFF
--- a/src/tests/TestCase.php
+++ b/src/tests/TestCase.php
@@ -18,26 +18,17 @@
  *  along with Spoof.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace spoof\tests\lib360\crypt;
+namespace spoof\tests;
 
-use spoof\tests\TestCase;
-
-class RandomTest extends TestCase
+abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
 
-    /**
-     * @covers \spoof\lib360\crypt\Random::getString
-     */
-    public function testGetString()
+    protected function getProtectedProperty($object, $property)
     {
-        $tries = 1000;
-        $result = array();
-        for ($i = 0; $i < $tries; ++$i) {
-            $key = \spoof\lib360\crypt\Random::getString(2, true, true);
-            $result[$key] = 1;
-        }
-        $actual = count($result);
-        $this->assertEquals($tries, $actual, "Expected $tries result, but got $actual");
+        $r = new \ReflectionClass($object);
+        $p = $r->getProperty($property);
+        $p->setAccessible(true);
+        return is_object($object) ? $p->getValue($object) : $p->getValue();
     }
 
 }

--- a/src/tests/Util.php
+++ b/src/tests/Util.php
@@ -20,8 +20,17 @@
 
 namespace spoof\tests;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+class Util
 {
+
+    public static function getProtectedProperty($objectOrClass, $property)
+    {
+        $r = new \ReflectionClass($objectOrClass);
+        $p = $r->getProperty($property);
+        $p->setAccessible(true);
+        return is_object($objectOrClass) ? $p->getValue($objectOrClass) : $p->getValue();
+    }
+
 }
 
 ?>

--- a/src/tests/lib360/db/condition/ConditionGroupTest.php
+++ b/src/tests/lib360/db/condition/ConditionGroupTest.php
@@ -23,8 +23,9 @@ namespace spoof\tests\lib360\db\condition;
 use spoof\lib360\db\condition\Condition;
 use spoof\lib360\db\condition\ConditionGroup;
 use spoof\lib360\db\value\Value;
+use spoof\tests\TestCase;
 
-class ConditionGroupTest extends \PHPUnit_Framework_TestCase
+class ConditionGroupTest extends TestCase
 {
 
     public $condition1;

--- a/src/tests/lib360/db/condition/ConditionTest.php
+++ b/src/tests/lib360/db/condition/ConditionTest.php
@@ -22,8 +22,9 @@ namespace spoof\tests\lib360\db\condition;
 
 use spoof\lib360\db\condition\Condition;
 use spoof\lib360\db\value\Value;
+use spoof\tests\TestCase;
 
-class ConditionTest extends \PHPUnit_Framework_TestCase
+class ConditionTest extends TestCase
 {
     /**
      * @covers \spoof\lib360\db\condition\Condition::__construct

--- a/src/tests/lib360/db/connection/ConfigTest.php
+++ b/src/tests/lib360/db/connection/ConfigTest.php
@@ -21,8 +21,9 @@
 namespace spoof\tests\lib360\db\connection;
 
 use spoof\lib360\db\connection\Config;
+use spoof\tests\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * @covers \spoof\lib360\db\connection\Config::__construct

--- a/src/tests/lib360/db/connection/ConnectionTest.php
+++ b/src/tests/lib360/db/connection/ConnectionTest.php
@@ -25,6 +25,7 @@ use spoof\lib360\db\connection\ConfigException;
 use spoof\lib360\db\object\Factory;
 use spoof\lib360\db\object\NotFoundException;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class ConnectionTest extends TestCase
 {
@@ -141,7 +142,7 @@ class ConnectionTest extends TestCase
         $c = new HelperConnection1($this->config1);
         $c->connect();
         $this->assertEquals(
-            $this->getProtectedProperty($c, 'connection'),
+            Util::getProtectedProperty($c, 'connection'),
             $c->getConnection(),
             "Failed to return correct connection property value"
         );

--- a/src/tests/lib360/db/connection/ConnectionTest.php
+++ b/src/tests/lib360/db/connection/ConnectionTest.php
@@ -24,8 +24,9 @@ use spoof\lib360\db\connection\Config;
 use spoof\lib360\db\connection\ConfigException;
 use spoof\lib360\db\object\Factory;
 use spoof\lib360\db\object\NotFoundException;
+use spoof\tests\TestCase;
 
-class ConnectionTest extends \PHPUnit_Framework_TestCase
+class ConnectionTest extends TestCase
 {
     public $configBad1;
     public $configBad2;
@@ -140,18 +141,10 @@ class ConnectionTest extends \PHPUnit_Framework_TestCase
         $c = new HelperConnection1($this->config1);
         $c->connect();
         $this->assertEquals(
-            $this->getProtectedProperty($c, 'connection')->getValue($c),
+            $this->getProtectedProperty($c, 'connection'),
             $c->getConnection(),
             "Failed to return correct connection property value"
         );
-    }
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**

--- a/src/tests/lib360/db/connection/PDOTest.php
+++ b/src/tests/lib360/db/connection/PDOTest.php
@@ -22,8 +22,9 @@ namespace spoof\tests\lib360\db\connection;
 
 use spoof\lib360\db\connection\Config;
 use spoof\lib360\db\connection\PDO;
+use spoof\tests\TestCase;
 
-class PDOTest extends \PHPUnit_Framework_TestCase
+class PDOTest extends TestCase
 {
 
     /**

--- a/src/tests/lib360/db/connection/PoolTest.php
+++ b/src/tests/lib360/db/connection/PoolTest.php
@@ -22,8 +22,9 @@ namespace spoof\tests\lib360\db\connection;
 
 use spoof\lib360\db\connection\Config;
 use spoof\lib360\db\connection\Pool;
+use spoof\tests\TestCase;
 
-class PoolTest extends \PHPUnit_Framework_TestCase
+class PoolTest extends TestCase
 {
     public $conn1;
     public $conn2;
@@ -60,17 +61,9 @@ class PoolTest extends \PHPUnit_Framework_TestCase
         }
         $this->assertArrayHasKey(
             'test2',
-            $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections')->getValue(),
+            $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections'),
             "Failed to create an internal array key with given label"
         );
-    }
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**
@@ -79,7 +72,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
      */
     public function testAdd_SuccessElementValue()
     {
-        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections')->getValue();
+        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
         $this->assertEquals($this->conn2, $c['test2'], "Connection object doesn't match");
     }
 
@@ -244,7 +237,7 @@ class PoolTest extends \PHPUnit_Framework_TestCase
     {
         Pool::add($this->conn1, 'test1');
         Pool::removeByName('test1');
-        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections')->getValue();
+        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
         $this->assertEquals(false, isset($c['test1']), "Failed to unset internal reference to connection object");
     }
 

--- a/src/tests/lib360/db/connection/PoolTest.php
+++ b/src/tests/lib360/db/connection/PoolTest.php
@@ -23,6 +23,7 @@ namespace spoof\tests\lib360\db\connection;
 use spoof\lib360\db\connection\Config;
 use spoof\lib360\db\connection\Pool;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class PoolTest extends TestCase
 {
@@ -61,7 +62,7 @@ class PoolTest extends TestCase
         }
         $this->assertArrayHasKey(
             'test2',
-            $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections'),
+            Util::getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections'),
             "Failed to create an internal array key with given label"
         );
     }
@@ -72,7 +73,7 @@ class PoolTest extends TestCase
      */
     public function testAdd_SuccessElementValue()
     {
-        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
+        $c = Util::getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
         $this->assertEquals($this->conn2, $c['test2'], "Connection object doesn't match");
     }
 
@@ -237,7 +238,7 @@ class PoolTest extends TestCase
     {
         Pool::add($this->conn1, 'test1');
         Pool::removeByName('test1');
-        $c = $this->getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
+        $c = Util::getProtectedProperty('\spoof\lib360\db\connection\Pool', 'connections');
         $this->assertEquals(false, isset($c['test1']), "Failed to unset internal reference to connection object");
     }
 

--- a/src/tests/lib360/db/data/RecordListTest.php
+++ b/src/tests/lib360/db/data/RecordListTest.php
@@ -22,8 +22,9 @@ namespace spoof\tests\lib360\db\data;
 
 use spoof\lib360\db\data\Record;
 use spoof\lib360\db\data\RecordList;
+use spoof\tests\TestCase;
 
-class RecordListTest extends \PHPUnit_Framework_TestCase
+class RecordListTest extends TestCase
 {
 
     /**

--- a/src/tests/lib360/db/data/RecordTest.php
+++ b/src/tests/lib360/db/data/RecordTest.php
@@ -22,6 +22,7 @@ namespace spoof\tests\lib360\db\data;
 
 use spoof\lib360\db\data\Record;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class RecordTest extends TestCase
 {
@@ -44,7 +45,7 @@ class RecordTest extends TestCase
         $record = new Record($type);
         $this->assertEquals(
             $type,
-            $this->getProtectedProperty($record, '__type'),
+            Util::getProtectedProperty($record, '__type'),
             "Failed to set custom type"
         );
     }

--- a/src/tests/lib360/db/data/RecordTest.php
+++ b/src/tests/lib360/db/data/RecordTest.php
@@ -21,8 +21,9 @@
 namespace spoof\tests\lib360\db\data;
 
 use spoof\lib360\db\data\Record;
+use spoof\tests\TestCase;
 
-class RecordTest extends \PHPUnit_Framework_TestCase
+class RecordTest extends TestCase
 {
 
     /**
@@ -43,20 +44,9 @@ class RecordTest extends \PHPUnit_Framework_TestCase
         $record = new Record($type);
         $this->assertEquals(
             $type,
-            $this->getProtectedProperty('\spoof\lib360\db\data\Record', '__type')->getValue($record),
+            $this->getProtectedProperty($record, '__type'),
             "Failed to set custom type"
         );
-    }
-
-    /**
-     * @covers \spoof\lib360\db\data\Record::__construct
-     */
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**

--- a/src/tests/lib360/db/data/StoreTest.php
+++ b/src/tests/lib360/db/data/StoreTest.php
@@ -25,6 +25,7 @@ use spoof\lib360\db\connection\Pool;
 use spoof\lib360\db\object\Factory;
 use spoof\tests\lib360\db\connection\HelperConnection1;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class StoreTest extends TestCase
 {
@@ -58,7 +59,7 @@ class StoreTest extends TestCase
     {
         $actual = $this->s->getName();
         $this->assertEquals(
-            $this->getProtectedProperty($this->s, 'name'),
+            Util::getProtectedProperty($this->s, 'name'),
             $actual,
             "getName didn't return the value of name property from extending class"
         );
@@ -71,7 +72,7 @@ class StoreTest extends TestCase
     {
         $actual = $this->s->getDB();
         $this->assertEquals(
-            $this->getProtectedProperty($this->s, 'db'),
+            Util::getProtectedProperty($this->s, 'db'),
             $actual,
             "getName didn't return the value of name property from extending class"
         );
@@ -133,7 +134,7 @@ class StoreTest extends TestCase
     public function testGetExecutor_Custom()
     {
         $this->assertEquals(
-            $this->getProtectedProperty($this->s2, 'executor'),
+            Util::getProtectedProperty($this->s2, 'executor'),
             $this->s2->getExecutor(), "Returned executor didn't match local custom executor specified"
         );
     }
@@ -144,7 +145,7 @@ class StoreTest extends TestCase
     public function testGetLanguage_Custom()
     {
         $this->assertEquals(
-            $this->getProtectedProperty($this->s2, 'language'),
+            Util::getProtectedProperty($this->s2, 'language'),
             $this->s2->getLanguage(), "Returned language didn't match local custom language specified"
         );
     }

--- a/src/tests/lib360/db/data/StoreTest.php
+++ b/src/tests/lib360/db/data/StoreTest.php
@@ -24,8 +24,9 @@ use spoof\lib360\db\connection\Config;
 use spoof\lib360\db\connection\Pool;
 use spoof\lib360\db\object\Factory;
 use spoof\tests\lib360\db\connection\HelperConnection1;
+use spoof\tests\TestCase;
 
-class StoreTest extends \PHPUnit_Framework_TestCase
+class StoreTest extends TestCase
 {
     protected $s;
     protected $s2;
@@ -57,18 +58,10 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     {
         $actual = $this->s->getName();
         $this->assertEquals(
-            $this->getProtectedProperty($this->s, 'name')->getValue($this->s),
+            $this->getProtectedProperty($this->s, 'name'),
             $actual,
             "getName didn't return the value of name property from extending class"
         );
-    }
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**
@@ -78,7 +71,7 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     {
         $actual = $this->s->getDB();
         $this->assertEquals(
-            $this->getProtectedProperty($this->s, 'db')->getValue($this->s),
+            $this->getProtectedProperty($this->s, 'db'),
             $actual,
             "getName didn't return the value of name property from extending class"
         );
@@ -140,7 +133,7 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     public function testGetExecutor_Custom()
     {
         $this->assertEquals(
-            $this->getProtectedProperty($this->s2, 'executor')->getValue($this->s2),
+            $this->getProtectedProperty($this->s2, 'executor'),
             $this->s2->getExecutor(), "Returned executor didn't match local custom executor specified"
         );
     }
@@ -151,7 +144,7 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     public function testGetLanguage_Custom()
     {
         $this->assertEquals(
-            $this->getProtectedProperty($this->s2, 'language')->getValue($this->s2),
+            $this->getProtectedProperty($this->s2, 'language'),
             $this->s2->getLanguage(), "Returned language didn't match local custom language specified"
         );
     }

--- a/src/tests/lib360/db/data/TableFactoryTest.php
+++ b/src/tests/lib360/db/data/TableFactoryTest.php
@@ -22,6 +22,7 @@ namespace spoof\tests\lib360\db\data;
 
 use spoof\lib360\db\data\TableFactory;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class TableFactoryTest extends TestCase
 {
@@ -33,7 +34,7 @@ class TableFactoryTest extends TestCase
     {
         $t1 = new HelperTable();
         TableFactory::cache($t1);
-        $p = $this->getProtectedProperty('\spoof\lib360\db\data\TableFactory', 'cache');
+        $p = Util::getProtectedProperty('\spoof\lib360\db\data\TableFactory', 'cache');
         $t2 = $p[$t1->getDB()][$t1->getName()];
         $this->assertEquals($t1, $t2, "Cached value is different from the returned value");
     }

--- a/src/tests/lib360/db/data/TableFactoryTest.php
+++ b/src/tests/lib360/db/data/TableFactoryTest.php
@@ -21,8 +21,9 @@
 namespace spoof\tests\lib360\db\data;
 
 use spoof\lib360\db\data\TableFactory;
+use spoof\tests\TestCase;
 
-class TableFactoryTest extends \PHPUnit_Framework_TestCase
+class TableFactoryTest extends TestCase
 {
 
     /**
@@ -32,17 +33,9 @@ class TableFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $t1 = new HelperTable();
         TableFactory::cache($t1);
-        $p = $this->getProtectedProperty('\spoof\lib360\db\data\TableFactory', 'cache')->getValue();
+        $p = $this->getProtectedProperty('\spoof\lib360\db\data\TableFactory', 'cache');
         $t2 = $p[$t1->getDB()][$t1->getName()];
         $this->assertEquals($t1, $t2, "Cached value is different from the returned value");
-    }
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**

--- a/src/tests/lib360/db/driver/DriverTest.php
+++ b/src/tests/lib360/db/driver/DriverTest.php
@@ -19,8 +19,9 @@
  */
 
 namespace spoof\tests\lib360\db\driver;
+use spoof\tests\TestCase;
 
-class DriverTest extends \PHPUnit_Framework_TestCase
+class DriverTest extends TestCase
 {
 
     /**

--- a/src/tests/lib360/db/join/JoinTest.php
+++ b/src/tests/lib360/db/join/JoinTest.php
@@ -23,8 +23,9 @@ namespace spoof\tests\lib360\db\join;
 use spoof\lib360\db\condition\Condition;
 use spoof\lib360\db\join\Join;
 use spoof\lib360\db\value\Value;
+use spoof\tests\TestCase;
 
-class JoinTest extends \PHPUnit_Framework_TestCase
+class JoinTest extends TestCase
 {
 
     /**

--- a/src/tests/lib360/db/language/SQLTest.php
+++ b/src/tests/lib360/db/language/SQLTest.php
@@ -28,8 +28,9 @@ use spoof\lib360\db\language\SQL;
 use spoof\lib360\db\language\SQLException;
 use spoof\lib360\db\query\Query;
 use spoof\lib360\db\value\Value;
+use spoof\tests\TestCase;
 
-class SQLTest extends \PHPUnit_Framework_TestCase
+class SQLTest extends TestCase
 {
 
     public $l;

--- a/src/tests/lib360/db/object/FactoryTest.php
+++ b/src/tests/lib360/db/object/FactoryTest.php
@@ -25,6 +25,7 @@ use spoof\lib360\db\object\Factory;
 use spoof\lib360\db\object\TypeNotFoundException;
 use spoof\lib360\db\object\UnexpectedObjectTypeException;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class FactoryTest extends TestCase
 {
@@ -105,7 +106,7 @@ class FactoryTest extends TestCase
     {
         Factory::get(Factory::OBJECT_TYPE_LANGUAGE, 'SQL');
         Factory::flushCache();
-        $actual = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'objects');
+        $actual = Util::getProtectedProperty('\spoof\lib360\db\object\Factory', 'objects');
         $expected = array();
         $this->assertEquals($expected, $actual, "Failed to flush object cache");
     }
@@ -186,7 +187,7 @@ class FactoryTest extends TestCase
     public function testGetType_Success()
     {
         $type = 'Driver';
-        $types = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'types');
+        $types = Util::getProtectedProperty('\spoof\lib360\db\object\Factory', 'types');
         $expected = $types[$type];
         $actual = Factory::getType($type);
         $this->assertEquals($expected, $actual, "Returned type definition didn't match internal values");

--- a/src/tests/lib360/db/object/FactoryTest.php
+++ b/src/tests/lib360/db/object/FactoryTest.php
@@ -24,8 +24,9 @@ use spoof\lib360\db\object\ClassNotFoundException;
 use spoof\lib360\db\object\Factory;
 use spoof\lib360\db\object\TypeNotFoundException;
 use spoof\lib360\db\object\UnexpectedObjectTypeException;
+use spoof\tests\TestCase;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
 
     /**
@@ -104,17 +105,9 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     {
         Factory::get(Factory::OBJECT_TYPE_LANGUAGE, 'SQL');
         Factory::flushCache();
-        $actual = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'objects')->getValue();
+        $actual = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'objects');
         $expected = array();
         $this->assertEquals($expected, $actual, "Failed to flush object cache");
-    }
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
     }
 
     /**
@@ -193,7 +186,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
     public function testGetType_Success()
     {
         $type = 'Driver';
-        $types = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'types')->getValue();
+        $types = $this->getProtectedProperty('\spoof\lib360\db\object\Factory', 'types');
         $expected = $types[$type];
         $actual = Factory::getType($type);
         $this->assertEquals($expected, $actual, "Returned type definition didn't match internal values");

--- a/src/tests/lib360/db/query/QueryTest.php
+++ b/src/tests/lib360/db/query/QueryTest.php
@@ -21,8 +21,9 @@
 namespace spoof\tests\lib360\db\query;
 
 use spoof\lib360\db\query\Query;
+use spoof\tests\TestCase;
 
-class QueryTest extends \PHPUnit_Framework_TestCase
+class QueryTest extends TestCase
 {
 
     /**

--- a/src/tests/lib360/db/value/ValueTest.php
+++ b/src/tests/lib360/db/value/ValueTest.php
@@ -24,6 +24,7 @@ use spoof\lib360\db\value\InvalidValueException;
 use spoof\lib360\db\value\UnknownTypeException;
 use spoof\lib360\db\value\Value;
 use spoof\tests\TestCase;
+use spoof\tests\Util;
 
 class ValueTest extends TestCase
 {
@@ -109,8 +110,8 @@ class ValueTest extends TestCase
         $this->assertEquals(
             array(null, Value::TYPE_NULL),
             array(
-                $this->getProtectedProperty($v, 'value'),
-                $this->getProtectedProperty($v, 'type'),
+                Util::getProtectedProperty($v, 'value'),
+                Util::getProtectedProperty($v, 'type'),
             ),
             "Failed to set null type and value"
         );
@@ -127,8 +128,8 @@ class ValueTest extends TestCase
         $this->assertEquals(
             array(null, Value::TYPE_NULL),
             array(
-                $this->getProtectedProperty($v, 'value'),
-                $this->getProtectedProperty($v, 'type'),
+                Util::getProtectedProperty($v, 'value'),
+                Util::getProtectedProperty($v, 'type'),
             ),
             "Failed to set null type and value"
         );

--- a/src/tests/lib360/db/value/ValueTest.php
+++ b/src/tests/lib360/db/value/ValueTest.php
@@ -23,17 +23,10 @@ namespace spoof\tests\lib360\db\value;
 use spoof\lib360\db\value\InvalidValueException;
 use spoof\lib360\db\value\UnknownTypeException;
 use spoof\lib360\db\value\Value;
+use spoof\tests\TestCase;
 
-class ValueTest extends \PHPUnit_Framework_TestCase
+class ValueTest extends TestCase
 {
-
-    protected function getProtectedProperty($class, $property)
-    {
-        $r = new \ReflectionClass($class);
-        $p = $r->getProperty($property);
-        $p->setAccessible(true);
-        return $p;
-    }
 
     public function test_ConstantsUnique()
     {
@@ -116,8 +109,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             array(null, Value::TYPE_NULL),
             array(
-                $this->getProtectedProperty($v, 'value')->getValue($v),
-                $this->getProtectedProperty($v, 'type')->getValue($v)
+                $this->getProtectedProperty($v, 'value'),
+                $this->getProtectedProperty($v, 'type'),
             ),
             "Failed to set null type and value"
         );
@@ -134,8 +127,8 @@ class ValueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(
             array(null, Value::TYPE_NULL),
             array(
-                $this->getProtectedProperty($v, 'value')->getValue($v),
-                $this->getProtectedProperty($v, 'type')->getValue($v)
+                $this->getProtectedProperty($v, 'value'),
+                $this->getProtectedProperty($v, 'type'),
             ),
             "Failed to set null type and value"
         );


### PR DESCRIPTION
This contains changes in tests only:

- created a `spoof\tests\Util` class and moved `getProtectedProperty` to it
- updated test classes that called `$this->getProtectedProperty` to `Util::getProtectedProperty`
- created a base unit test class which all non-database test classes extend
- fixed a minor bug in how `getProtectedProperty` was called from `RecordTest`

Closes #21.